### PR TITLE
Fix: default content-type response is now the elife type

### DIFF
--- a/src/bp/tests/bp_tests.py
+++ b/src/bp/tests/bp_tests.py
@@ -412,12 +412,12 @@ class APIViews(TestCase):
         self.assertEqual(resp.status_code, 404)
 
     def test_article_protocol(self):
-        "a request for an article exists returns, 200 successful request"
+        "a request for an article that exists returns a 200 successful request with correct content-type"
         fixture = join(FIXTURE_DIR, "bp-post-to-elife.json")
         logic.add_result(json.load(open(fixture, "r")))
         resp = self.c.get(self.article_url)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp["Content-Type"], "application/json")
+        self.assertEqual(resp["Content-Type"], settings.ELIFE_CONTENT_TYPE)
 
     def test_article_protocol_head(self):
         "a HEAD request for an article that exists returns, 200 successful request"
@@ -462,13 +462,13 @@ class APIViews(TestCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_article_protocol_post_bad_encoding(self):
-        "a POST request with good data but bad content-encoding header returns a failed response"
+        "a POST request with good data but bad a content-encoding header returns a failed response"
         fixture = join(FIXTURE_DIR, "bp-post-to-elife.json")
         post_body = json.load(open(fixture, "r"))["data"]
         resp = self.c.post(
             self.article_url, json.dumps(post_body), content_type="text/plain"
         )
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 406)
 
     def test_article_protocol_post_bad_data(self):
         "a POST request with bad data returns a failed response"

--- a/src/bp/tests/bp_tests.py
+++ b/src/bp/tests/bp_tests.py
@@ -462,7 +462,7 @@ class APIViews(TestCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_article_protocol_post_bad_encoding(self):
-        "a POST request with good data but bad a content-encoding header returns a failed response"
+        "a POST request with good data but a bad content-encoding header returns a failed response"
         fixture = join(FIXTURE_DIR, "bp-post-to-elife.json")
         post_body = json.load(open(fixture, "r"))["data"]
         resp = self.c.post(

--- a/src/bp/tests/bp_tests.py
+++ b/src/bp/tests/bp_tests.py
@@ -461,6 +461,18 @@ class APIViews(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
 
+    def test_article_protocol_post_wonky_encoding_2(self):
+        "a POST request with good article data but a slightly wonky content_type still makes it through"
+        fixture = join(FIXTURE_DIR, "bp-post-to-elife.json")
+        post_body = json.load(open(fixture, "r"))["data"]
+        # (space in-between mime and parameters)
+        resp = self.c.post(
+            self.article_url,
+            json.dumps(post_body),
+            content_type="application/vnd.elife.bioprotocol+json; version=1",
+        )
+        self.assertEqual(resp.status_code, 200)
+
     def test_article_protocol_post_bad_encoding(self):
         "a POST request with good data but a bad content-encoding header returns a failed response"
         fixture = join(FIXTURE_DIR, "bp-post-to-elife.json")

--- a/src/bp/views.py
+++ b/src/bp/views.py
@@ -47,7 +47,7 @@ def article(request, msid):
             content_encoding = request.content_type.strip().lower()
             if (
                 "application/json" not in content_encoding
-                and settings.ELIFE_CONTENT_TYPE not in content_encoding
+                and settings.ELIFE_CONTENT_TYPE_GENERAL not in content_encoding
             ):
                 return error("unable to negotiate a content encoding", 406)
             try:

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -123,6 +123,7 @@ DATABASES = {
 SQS = cfg("sqs")
 ELIFE_GATEWAY = cfg("gateway.host")
 ELIFE_CONTENT_TYPE = "application/vnd.elife.bioprotocol+json;version=1"
+ELIFE_CONTENT_TYPE_GENERAL = "application/vnd.elife.bioprotocol+json"
 BP = cfg("bioprotocol")
 
 LANGUAGE_CODE = "en-us"


### PR DESCRIPTION
* default content-type response is now the custom elife type rather than application/json
* cleans up some of the overzealous content negotiation

cc @giorgiosironi 